### PR TITLE
fix(grammar): correct block scalar modifier regex to match YAML spec

### DIFF
--- a/syntaxes/github-actions-github-script.injection.tmLanguage.json
+++ b/syntaxes/github-actions-github-script.injection.tmLanguage.json
@@ -35,7 +35,7 @@
           "patterns": [
             {
               "contentName": "meta.embedded.block.javascript",
-              "begin": "^(\\s+)(script)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+              "begin": "^(\\s+)(script)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
               "beginCaptures": {
                 "2": {
                   "name": "entity.name.tag.yaml"

--- a/syntaxes/github-actions-run-shell.injection.tmLanguage.json
+++ b/syntaxes/github-actions-run-shell.injection.tmLanguage.json
@@ -55,7 +55,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.shellscript",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -97,7 +97,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.powershell",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -139,7 +139,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.bat",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -181,7 +181,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.python",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -223,7 +223,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.javascript",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -164,6 +164,15 @@ test('matches slash-containing github-script refs and ignores non-with script ke
   assert.ok(!result.scriptBodyLines.has(12), 'env.script body should remain plain YAML');
 });
 
+test('script header regex accepts valid block scalar modifiers and rejects invalid ones', () => {
+  for (const valid of ['|', '|-', '|+', '|2', '>-', '>+', '>2', '|-2', '|2-']) {
+    assert.ok(scriptBegin.test(`          script: ${valid}`), `should match: script: ${valid}`);
+  }
+  for (const invalid of ['|0', '|+-', '|22', '|-+', '>0', '>-+']) {
+    assert.ok(!scriptBegin.test(`          script: ${invalid}`), `should reject: script: ${invalid}`);
+  }
+});
+
 test('script header regex preserves YAML-like capture groups', () => {
   const match = scriptBegin.exec('          script: |');
 

--- a/test/run-shell-grammar.test.js
+++ b/test/run-shell-grammar.test.js
@@ -153,6 +153,18 @@ test('shell header regex captures YAML-like pieces for each shell context', () =
   }
 });
 
+test('run header regex accepts valid block scalar modifiers and rejects invalid ones', () => {
+  const ctx = compileTopLevelContexts()[0]; // shell-bash
+  const runBegin = ctx.runBegin;
+
+  for (const valid of ['|', '|-', '|+', '|2', '>-', '>+', '>2', '|-2', '|2-', '>+9', '>9+']) {
+    assert.ok(runBegin.test(`        run: ${valid}`), `should match: run: ${valid}`);
+  }
+  for (const invalid of ['|0', '|+-', '|22', '|-+', '>0', '>-+', '>22']) {
+    assert.ok(!runBegin.test(`        run: ${invalid}`), `should reject: run: ${invalid}`);
+  }
+});
+
 test('run-shell grammar scope name matches the packaged contribution and schema pattern', () => {
   const scopeNamePattern = /^(text|source)(\.[\w0-9-]+)+$/;
   const contribution = packageJson.contributes.grammars.find(


### PR DESCRIPTION
## Summary
- Replace overly permissive block scalar regex `([>|][-+0-9\s]*\s*)` with spec-correct `([>|](?:[-+][1-9]?|[1-9][-+]?)?\s*)` across all 6 occurrences in both grammar files
- Rejects invalid YAML sequences like `|0`, `|+-`, `|22` that the old pattern accepted
- Removes `\s` from the character class that overlapped with the trailing `\s*`

## Test plan
- [x] All 13 existing tests pass
- [ ] Verify `|`, `|-`, `|+`, `|2`, `|+2`, `|2+`, `>-`, `>+`, `>2` are accepted
- [ ] Verify `|0`, `|+-`, `|22`, `|-+` are rejected