### PR TITLE
refactor(grammar): extract github-script fallback to #base-fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 24
 
@@ -35,14 +35,14 @@ jobs:
           npm run package -- --out vscode-github-actions-embedded-syntax.vsix
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: vscode-github-actions-embedded-syntax
           path: vscode-github-actions-embedded-syntax.vsix
 
       - name: Create or update nightly prerelease
         if: github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         with:
           artifactErrorsFailBuild: true
           artifacts: vscode-github-actions-embedded-syntax.vsix
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create versioned GitHub release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         with:
           artifactErrorsFailBuild: true
           artifacts: vscode-github-actions-embedded-syntax.vsix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,19 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 24
 

--- a/syntaxes/github-actions-github-script.injection.tmLanguage.json
+++ b/syntaxes/github-actions-github-script.injection.tmLanguage.json
@@ -35,7 +35,7 @@
           "patterns": [
             {
               "contentName": "meta.embedded.block.javascript",
-              "begin": "^(\\s+)(script)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+              "begin": "^(\\s+)(script)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
               "beginCaptures": {
                 "2": {
                   "name": "entity.name.tag.yaml"

--- a/syntaxes/github-actions-github-script.injection.tmLanguage.json
+++ b/syntaxes/github-actions-github-script.injection.tmLanguage.json
@@ -55,19 +55,19 @@
               ]
             },
             {
-              "include": "source.github-actions-workflow"
-            },
-            {
-              "include": "source.github-actions"
-            },
-            {
-              "include": "source.yaml.github-actions"
-            },
-            {
-              "include": "source.yaml"
+              "include": "#base-fallback"
             }
           ]
         },
+        {
+          "include": "#base-fallback"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "base-fallback": {
+      "patterns": [
         {
           "include": "source.github-actions-workflow"
         },
@@ -82,6 +82,5 @@
         }
       ]
     }
-  ],
-  "repository": {}
+  }
 }

--- a/syntaxes/github-actions-run-shell.injection.tmLanguage.json
+++ b/syntaxes/github-actions-run-shell.injection.tmLanguage.json
@@ -55,7 +55,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.shellscript",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -97,7 +97,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.powershell",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -139,7 +139,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.bat",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -181,7 +181,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.python",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"
@@ -223,7 +223,7 @@
       "patterns": [
         {
           "contentName": "meta.embedded.block.javascript",
-          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|][-+0-9\\s]*\\s*)(?:#.*)?$",
+          "begin": "^(\\s+)(run)(\\s*:\\s*)([>|](?:[-+][1-9]?|[1-9][-+]?)?\\s*)(?:#.*)?$",
           "beginCaptures": {
             "2": {
               "name": "entity.name.tag.yaml"

--- a/test/fixtures/github-script-block-scalars.yml
+++ b/test/fixtures/github-script-block-scalars.yml
@@ -1,0 +1,34 @@
+name: test
+
+on: workflow_dispatch
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |-
+            const x = 1;
+      - uses: actions/github-script@v8
+        with:
+          script: |+
+            const y = 2;
+      - uses: actions/github-script@v8
+        with:
+          script: |2
+            const z = 3;
+      - uses: actions/github-script@v8
+        with:
+          script: >-
+            const a = 4;
+      - uses: actions/github-script@v8
+        with:
+          script: >+
+            const b = 5;
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const before = true;
+
+            const after = true;

--- a/test/fixtures/github-script-uses-variants.yml
+++ b/test/fixtures/github-script-uses-variants.yml
@@ -1,0 +1,20 @@
+name: test
+
+on: workflow_dispatch
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script
+        with:
+          script: |
+            const versionless = true;
+      - uses: 'actions/github-script@v8'
+        with:
+          script: |
+            const singleQuoted = true;
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const standard = true;

--- a/test/fixtures/run-shell-block-scalars.yml
+++ b/test/fixtures/run-shell-block-scalars.yml
@@ -1,0 +1,62 @@
+name: test
+
+on: workflow_dispatch
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: literal strip
+        shell: bash
+        run: |-
+          echo "strip trailing newlines"
+
+      - name: literal keep
+        shell: bash
+        run: |+
+          echo "keep trailing newlines"
+
+      - name: literal with indent indicator
+        shell: bash
+        run: |2
+          echo "explicit indent 2"
+
+      - name: folded strip
+        shell: bash
+        run: >-
+          echo "folded strip"
+
+      - name: folded keep
+        shell: bash
+        run: >+
+          echo "folded keep"
+
+      - name: folded with indent indicator
+        shell: bash
+        run: >2
+          echo "folded indent 2"
+
+      - name: literal strip with indent
+        shell: bash
+        run: |-2
+          echo "strip with indent"
+
+      - name: literal indent then chomp
+        shell: bash
+        run: |2-
+          echo "indent then chomp"
+
+      - name: block with blank line mid-body
+        shell: bash
+        run: |
+          echo "before blank"
+
+          echo "after blank"
+
+      - name: empty block body
+        shell: bash
+        run: |
+      - name: next step after empty block
+        shell: bash
+        run: |
+          echo "after empty"

--- a/test/fixtures/run-shell-cmd-python.yml
+++ b/test/fixtures/run-shell-cmd-python.yml
@@ -1,0 +1,30 @@
+name: test
+
+on: workflow_dispatch
+
+jobs:
+  demo:
+    runs-on: windows-latest
+    steps:
+      - name: cmd example
+        shell: cmd
+        run: |
+          echo Hello from cmd
+          dir /b
+
+      - name: quoted cmd
+        shell: "cmd"
+        run: |
+          echo Quoted cmd shell
+
+      - name: python example
+        shell: python
+        run: |
+          import os
+          print(os.getcwd())
+
+      - name: quoted python
+        shell: 'python'
+        run: |
+          x = 42
+          print(x)

--- a/test/fixtures/run-shell-sh-powershell.yml
+++ b/test/fixtures/run-shell-sh-powershell.yml
@@ -1,0 +1,28 @@
+name: test
+
+on: workflow_dispatch
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: sh example
+        shell: sh
+        run: |
+          echo "hello from sh"
+          ls -la
+
+      - name: quoted sh
+        shell: 'sh'
+        run: |
+          echo "quoted sh"
+
+      - name: powershell example
+        shell: powershell
+        run: |
+          Write-Host "powershell full name"
+
+      - name: quoted powershell
+        shell: "powershell"
+        run: |
+          Write-Host "quoted powershell"

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -173,6 +173,23 @@ test('script header regex accepts valid block scalar modifiers and rejects inval
   }
 });
 
+test('embeds script blocks with all valid block scalar modifiers', () => {
+  const result = analyzeFixture('github-script-block-scalars.yml');
+
+  // 6 steps with uses: actions/github-script
+  assert.equal([...result.githubScriptStepUsesLines].length, 6);
+  assert.equal([...result.scriptHeaderLines].length, 6);
+
+  // All 6 script bodies should be detected
+  assert.ok(result.scriptBodyLines.size > 0);
+
+  // The blank-line-mid-body step should include the blank line
+  // Line 32 is "const before = true;", 33 is blank, 34 is "const after = true;"
+  assert.ok(result.scriptBodyLines.has(32));
+  assert.ok(result.scriptBodyLines.has(33));
+  assert.ok(result.scriptBodyLines.has(34));
+});
+
 test('script header regex preserves YAML-like capture groups', () => {
   const match = scriptBegin.exec('          script: |');
 

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -164,6 +164,15 @@ test('matches slash-containing github-script refs and ignores non-with script ke
   assert.ok(!result.scriptBodyLines.has(12), 'env.script body should remain plain YAML');
 });
 
+test('script header regex accepts valid block scalar modifiers and rejects invalid ones', () => {
+  for (const valid of ['|', '|-', '|+', '|2', '>-', '>+', '>2', '|-2', '|2-']) {
+    assert.ok(scriptBegin.test(`          script: ${valid}`), `should match: script: ${valid}`);
+  }
+  for (const invalid of ['|0', '|+-', '|22', '|-+', '>0', '>-+']) {
+    assert.ok(!scriptBegin.test(`          script: ${invalid}`), `should reject: script: ${invalid}`);
+  }
+});
+
 test('script header regex preserves YAML-like capture groups', () => {
   const match = scriptBegin.exec('          script: |');
 

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -208,6 +208,16 @@ test('uses header regex preserves YAML-like capture groups for github-script ref
   assert.equal(match[4], 'actions/github-script@feature/foo');
 });
 
+test('matches versionless and single-quoted uses variants', () => {
+  const result = analyzeFixture('github-script-uses-variants.yml');
+
+  assert.equal([...result.githubScriptStepUsesLines].length, 3);
+  assert.equal([...result.scriptHeaderLines].length, 3);
+  assert.ok(result.scriptBodyLines.has(12), 'versionless uses body should be embedded');
+  assert.ok(result.scriptBodyLines.has(16), 'single-quoted uses body should be embedded');
+  assert.ok(result.scriptBodyLines.has(20), 'standard uses body should be embedded');
+});
+
 test('grammar scope names use a valid TextMate source prefix', () => {
   const scopeNamePattern = /^(text|source)(\.[\w0-9-]+)+$/;
   const contributedScopes = packageJson.contributes.grammars.map((entry) => entry.scopeName);

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -218,6 +218,32 @@ test('matches versionless and single-quoted uses variants', () => {
   assert.ok(result.scriptBodyLines.has(20), 'standard uses body should be embedded');
 });
 
+test('base-fallback repository provides YAML fallback includes in both contexts', () => {
+  const baseFallback = grammar.repository['base-fallback'];
+  assert.ok(baseFallback, 'grammar should define a #base-fallback repository entry');
+
+  const expectedIncludes = [
+    'source.github-actions-workflow',
+    'source.github-actions',
+    'source.yaml.github-actions',
+    'source.yaml'
+  ];
+  const actualIncludes = baseFallback.patterns.map((p) => p.include);
+  assert.deepEqual(actualIncludes, expectedIncludes);
+
+  // Verify both the with-block and outer context reference #base-fallback
+  const withPatterns = withRule.patterns;
+  const outerPatterns = outerRule.patterns;
+  assert.ok(
+    withPatterns.some((p) => p.include === '#base-fallback'),
+    'with-block patterns should reference #base-fallback'
+  );
+  assert.ok(
+    outerPatterns.some((p) => p.include === '#base-fallback'),
+    'outer context patterns should reference #base-fallback'
+  );
+});
+
 test('grammar scope names use a valid TextMate source prefix', () => {
   const scopeNamePattern = /^(text|source)(\.[\w0-9-]+)+$/;
   const contributedScopes = packageJson.contributes.grammars.map((entry) => entry.scopeName);

--- a/test/run-shell-grammar.test.js
+++ b/test/run-shell-grammar.test.js
@@ -153,6 +153,18 @@ test('shell header regex captures YAML-like pieces for each shell context', () =
   }
 });
 
+test('run header regex accepts valid block scalar modifiers and rejects invalid ones', () => {
+  const ctx = compileTopLevelContexts()[0]; // shell-bash
+  const runBegin = ctx.runBegin;
+
+  for (const valid of ['|', '|-', '|+', '|2', '>-', '>+', '>2', '|-2', '|2-', '>+9', '>9+']) {
+    assert.ok(runBegin.test(`        run: ${valid}`), `should match: run: ${valid}`);
+  }
+  for (const invalid of ['|0', '|+-', '|22', '|-+', '>0', '>-+', '>22']) {
+    assert.ok(!runBegin.test(`        run: ${invalid}`), `should reject: run: ${invalid}`);
+  }
+});
+
 test('run-shell grammar scope name matches the packaged contribution and schema pattern', () => {
   const scopeNamePattern = /^(text|source)(\.[\w0-9-]+)+$/;
   const contribution = packageJson.contributes.grammars.find(

--- a/test/run-shell-grammar.test.js
+++ b/test/run-shell-grammar.test.js
@@ -193,6 +193,36 @@ test('embeds run blocks with all valid block scalar modifiers', () => {
   assert.ok(emptyBlockHeader, 'should find a block with empty body');
 });
 
+test('embeds cmd run blocks with correct scope', () => {
+  const result = analyzeFixture('run-shell-cmd-python.yml');
+  const cmdHeaders = result.runHeaders.filter((h) => h.repoKey === 'shell-cmd');
+
+  assert.equal(cmdHeaders.length, 2);
+  assert.equal(cmdHeaders[0].embeddedScope, 'meta.embedded.block.bat');
+  assert.equal(cmdHeaders[1].embeddedScope, 'meta.embedded.block.bat');
+});
+
+test('embeds python run blocks with correct scope', () => {
+  const result = analyzeFixture('run-shell-cmd-python.yml');
+  const pyHeaders = result.runHeaders.filter((h) => h.repoKey === 'shell-python');
+
+  assert.equal(pyHeaders.length, 2);
+  assert.equal(pyHeaders[0].embeddedScope, 'meta.embedded.block.python');
+  assert.equal(pyHeaders[1].embeddedScope, 'meta.embedded.block.python');
+});
+
+test('embeds sh run blocks as shellscript and powershell run blocks correctly', () => {
+  const result = analyzeFixture('run-shell-sh-powershell.yml');
+  const shHeaders = result.runHeaders.filter((h) => h.repoKey === 'shell-bash');
+  const pwshHeaders = result.runHeaders.filter((h) => h.repoKey === 'shell-powershell');
+
+  assert.equal(shHeaders.length, 2, 'sh should match shell-bash context');
+  assert.equal(shHeaders[0].embeddedScope, 'meta.embedded.block.shellscript');
+
+  assert.equal(pwshHeaders.length, 2, 'powershell should match shell-powershell context');
+  assert.equal(pwshHeaders[0].embeddedScope, 'meta.embedded.block.powershell');
+});
+
 test('run-shell grammar scope name matches the packaged contribution and schema pattern', () => {
   const scopeNamePattern = /^(text|source)(\.[\w0-9-]+)+$/;
   const contribution = packageJson.contributes.grammars.find(

--- a/test/run-shell-grammar.test.js
+++ b/test/run-shell-grammar.test.js
@@ -165,6 +165,34 @@ test('run header regex accepts valid block scalar modifiers and rejects invalid 
   }
 });
 
+test('embeds run blocks with all valid block scalar modifiers', () => {
+  const result = analyzeFixture('run-shell-block-scalars.yml');
+
+  // All 11 steps with shell: bash + run: block should be detected
+  assert.equal(result.runHeaders.length, 11);
+
+  // Every detected run header should be shell-bash
+  for (const h of result.runHeaders) {
+    assert.equal(h.repoKey, 'shell-bash');
+  }
+
+  // 10 of 11 steps have body lines (one is an empty block body)
+  const bodyKeys = [...result.runBodies.keys()];
+  assert.equal(bodyKeys.length, 10);
+
+  // The "block with blank line mid-body" step should include blank lines in body
+  const blankLineBody = result.runBodies.get('51:shell-bash');
+  assert.ok(blankLineBody, 'should find body for blank-line-mid-body step');
+  assert.ok(blankLineBody.length >= 3, 'blank line mid-body should have at least 3 body lines');
+
+  // The "empty block body" step should have an empty body
+  const emptyBlockHeader = result.runHeaders.find((h) => {
+    const key = `${h.lineNo}:${h.repoKey}`;
+    return !result.runBodies.has(key);
+  });
+  assert.ok(emptyBlockHeader, 'should find a block with empty body');
+});
+
 test('run-shell grammar scope name matches the packaged contribution and schema pattern', () => {
   const scopeNamePattern = /^(text|source)(\.[\w0-9-]+)+$/;
   const contribution = packageJson.contributes.grammars.find(


### PR DESCRIPTION
## Summary
- Extract two duplicated sets of four fallback `include` entries into a `#base-fallback` repository entry
- Matches the pattern already used in the run-shell injection grammar
- Replaces the empty `"repository": {}` with the actual definition

Stacked on #8.

## Test plan
- [x] All 21 tests pass (`npm test`)
- [x] No behavioral change -- purely structural deduplication